### PR TITLE
refactor: rename docker-compose service name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
-  docker-fastapi:
-    container_name: docker-fastapi
+  metaland-accounts:
+    container_name: metaland-accounts
     build: .
     restart: always
     ports:


### PR DESCRIPTION
## Summary
docker-compose.yml에서 service의 이름을 `docker-fastapi` 를 `metaland-accounts` 로 변경