### PR TITLE
`docker-compose.yml` 에서 소스 코드 volume이 잘못 매핑되어 있는 오류 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - ./mtl_accounts:/mtl_accounts
+      - .:/metaland-accounts
     environment:
       - OAUTHLIB_INSECURE_TRANSPORT=${OAUTHLIB_INSECURE_TRANSPORT}
       - MY_CLIENT_ID=${MY_CLIENT_ID}


### PR DESCRIPTION
## Summary
* 이 PR은 `docker-compose.yml` 에서 잘못된 소스 코드 폴더가 컨테이너 내부 볼륨에 마운트 되어있는 이슈를 해결
* 자세한 사항은 #39 확인

## Related Issue
Close #39 