### PR TITLE
`run.py` 의 엔트리포인트를 올바르게 수정

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,9 +1,7 @@
 import uvicorn
 from dotenv import load_dotenv
 
-from mtl_accounts.main import app
-
 load_dotenv(verbose=True)
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("mtl_accounts.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
* `run.py` 의 엔트리포인트를 String `mtl_accounts.main:app` 으로 변경
* 서버가 오류가 뜨면서 켜지지 않는 버그를 수정

## Related Issue
* Close #57 