### PR TITLE
User에 id 필드 추가 및 jwt 발급 시 `subject` 를 id 로 설정

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -1,13 +1,12 @@
 CREATE SCHEMA metaland_accounts;
-
 CREATE TABLE metaland_accounts.minecraft_account (
     id character varying(50) NOT NULL,
-    user_email character varying(50) DEFAULT NULL::character varying,
+    user_id character varying(50) DEFAULT NULL::character varying,
     provider character varying(50),
     "display_name" character varying(50) DEFAULT NULL::character varying
 );
-
 CREATE TABLE metaland_accounts.users (
+    id character varying(36) NOT NULL,
     email character varying(50) NOT NULL,
     role character varying(50),
     phone_number character varying(50),
@@ -16,18 +15,9 @@ CREATE TABLE metaland_accounts.users (
     "given_name" character varying(50),
     "job_title" character varying(50)
 );
-
-
 ALTER TABLE ONLY metaland_accounts.minecraft_account
-    ADD CONSTRAINT minecraft_account_pkey PRIMARY KEY (id);
-
-
+ADD CONSTRAINT minecraft_account_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY metaland_accounts.users
-    ADD CONSTRAINT users_pkey PRIMARY KEY (email);
-
-
+ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY metaland_accounts.minecraft_account
-    ADD CONSTRAINT minecraft_account_user_eemail_fkey FOREIGN KEY (user_email) REFERENCES metaland_accounts.users(email);
-
-
-
+ADD CONSTRAINT minecraft_account_user_id_fkey FOREIGN KEY (user_id) REFERENCES metaland_accounts.users(id);

--- a/mtl_accounts/database/crud.py
+++ b/mtl_accounts/database/crud.py
@@ -19,13 +19,13 @@ def exists_mincraft(session: Session, id: str) -> bool:
     return False
 
 
-def create_or_update_user(session: Session, user: OpenID, defaults: Dict = {}) -> User:
-    updates = session.query(Users).filter(Users.email == user.email).update(user.dict())
+def create_or_update_user(session: Session, openid: OpenID, defaults: Dict = {}) -> User:
+    updates = session.query(Users).filter(and_(Users.provider == openid.provider, Users.email == openid.email)).update(openid.dict())
     if not updates:
-        session.add(Users(**User(**{**user.dict(), **defaults}).dict()))
+        session.add(Users(**User(**{**openid.dict(), **defaults}).dict()))
     session.commit()
 
-    account = session.query(Users).filter(Users.email == user.email).first()
+    account = session.query(Users).filter(Users.email == openid.email).first()
     return User.from_orm(account)  # https://pydantic-docs.helpmanual.io/usage/models/#orm-mode-aka-arbitrary-class-instances
 
 

--- a/mtl_accounts/database/schema.py
+++ b/mtl_accounts/database/schema.py
@@ -1,17 +1,20 @@
+import uuid
 from math import ceil
 from typing import Generic, List, Sequence, TypeVar
 
 from fastapi_pagination import Params
 from fastapi_pagination.bases import AbstractPage, AbstractParams
 from mtl_accounts.database.conn import Base
-from sqlalchemy import VARCHAR, Column, ForeignKey
+from mtl_accounts.models import Role
+from sqlalchemy import TIMESTAMP, VARCHAR, Column, ForeignKey
 
 
 class Users(Base):
     __tablename__ = "users"
     __table_args__ = {"schema": "metaland_accounts"}
+    id = Column(VARCHAR(36), primary_key=True, index=True, default=uuid.uuid4)
     email = Column(VARCHAR(50), primary_key=True, index=True)
-    role = Column(VARCHAR(50), default="default")
+    role = Column(VARCHAR(50), default=Role.default.value)
     phone_number = Column(VARCHAR(50), nullable=True)
     provider = Column(VARCHAR(50), nullable=True)
     display_name = Column(VARCHAR(50), nullable=True)
@@ -23,7 +26,7 @@ class Minecraft_Account(Base):
     __tablename__ = "minecraft_account"
     __table_args__ = {"schema": "metaland_accounts"}
     id = Column(VARCHAR(50), primary_key=True, index=True)
-    user_email = Column(VARCHAR(50), ForeignKey("metaland_accounts.users.email"))
+    user_id = Column(VARCHAR(50), ForeignKey("metaland_accounts.users.id"))
     provider = Column(VARCHAR(50), nullable=True)
     display_name = Column(VARCHAR(50), nullable=True)
 

--- a/mtl_accounts/models.py
+++ b/mtl_accounts/models.py
@@ -24,6 +24,7 @@ class OpenID(BaseModel):
 
 
 class User(OpenID):
+    id: str = None
     role: str = Role.default.value
 
     class Config:

--- a/mtl_accounts/routes/kakao.py
+++ b/mtl_accounts/routes/kakao.py
@@ -40,10 +40,10 @@ async def kakao_callback(request: Request, Authorize: AuthJWT = Depends(), sessi
 
     account = create_or_update_user(session, user)
 
-    access_token = Authorize.create_access_token(subject=account.email, user_claims=account.dict())
+    access_token = Authorize.create_access_token(subject=account.id, user_claims=account.dict())
     response = RedirectResponse(f"{JWT_REDIRECT_URL}#access_token={access_token}")
 
-    refresh_token = Authorize.create_refresh_token(subject=account.email, user_claims=account.dict())
+    refresh_token = Authorize.create_refresh_token(subject=account.id, user_claims=account.dict())
 
     Authorize.set_refresh_cookies(refresh_token, response, max_age=1209600)
 

--- a/mtl_accounts/routes/microsoft.py
+++ b/mtl_accounts/routes/microsoft.py
@@ -47,10 +47,10 @@ async def microsoft_callback(request: Request, Authorize: AuthJWT = Depends(), s
 
     account = create_or_update_user(session, user, defaults)
 
-    access_token = Authorize.create_access_token(subject=account.email, user_claims=account.dict())
+    access_token = Authorize.create_access_token(subject=account.id, user_claims=account.dict())
     response = RedirectResponse(f"{JWT_REDIRECT_URL}#access_token={access_token}")
 
-    refresh_token = Authorize.create_refresh_token(subject=account.email, user_claims=account.dict())
+    refresh_token = Authorize.create_refresh_token(subject=account.id, user_claims=account.dict())
 
     Authorize.set_refresh_cookies(refresh_token, response, max_age=1209600)
 

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from typing import Dict
 
 import pytest
@@ -12,6 +13,7 @@ fake = Faker("ko_KR")
 
 def create_user():
     return {
+        "id": uuid.uuid4(),
         "display_name": fake.name(),
         "given_name": "null",
         "job_title": fake.job(),
@@ -29,7 +31,7 @@ def build_access_token(
     expires = expires = issued_at - 1 if expired else issued_at + 900
 
     return Authorize._create_token(
-        subject=claims["display_name"],
+        subject=claims["id"],
         type_token="access",
         exp_time=expires,
         algorithm="HS256",


### PR DESCRIPTION
## Summary
* 이메일은 노출되서는 안될 개인 정보이며, 이러한 특성상 Front-end에서 취급하기가 너무 까다로움
* 따라서 `metaland` 시스템내에서 유저를 식별할 수 있는 `id` 필드를 추가
* `id` 필드는 `uuid4` 가 사용됨
* JWT 발급 시 `subject` 는 id 값을 사용하도록 변경

## Related Issue
* Close #93 