### PR TITLE
Redirect URL에 access_token 제거

### DIFF
--- a/mtl_accounts/routes/kakao.py
+++ b/mtl_accounts/routes/kakao.py
@@ -39,13 +39,8 @@ async def kakao_login():
 async def kakao_callback(request: Request, Authorize: AuthJWT = Depends(), session: Session = Depends(db.session)):
     user = await kakao_sso.verify_and_process(request)
 
+    response = RedirectResponse(JWT_REDIRECT_URL)
     account = create_or_update_user(session, user)
-
-    access_token = Authorize.create_access_token(subject=account.id, user_claims=json.loads(account.json()))
-    response = RedirectResponse(f"{JWT_REDIRECT_URL}#access_token={access_token}")
-
     refresh_token = Authorize.create_refresh_token(subject=account.id, user_claims=json.loads(account.json()))
-
     Authorize.set_refresh_cookies(refresh_token, response, max_age=1209600)
-
     return response

--- a/mtl_accounts/routes/microsoft.py
+++ b/mtl_accounts/routes/microsoft.py
@@ -46,15 +46,10 @@ async def microsoft_callback(request: Request, Authorize: AuthJWT = Depends(), s
     if user.email.endswith("@office.deu.ac.kr"):
         defaults["role"] = Role.student
 
+    response = RedirectResponse(JWT_REDIRECT_URL)
     account = create_or_update_user(session, user, defaults)
-
-    access_token = Authorize.create_access_token(subject=account.id, user_claims=json.loads(account.json()))
-    response = RedirectResponse(f"{JWT_REDIRECT_URL}#access_token={access_token}")
-
     refresh_token = Authorize.create_refresh_token(subject=account.id, user_claims=json.loads(account.json()))
-
     Authorize.set_refresh_cookies(refresh_token, response, max_age=1209600)
-
     return response
 
 


### PR DESCRIPTION
## Summary
* Front-end에서 `/refresh` 를 통해 access_token을 얻어오기 때문에 Redirect URL로 전달될 필요 없음

## Related Issue
* Close #99 